### PR TITLE
Add Section Headers

### DIFF
--- a/CourseGrab.xcodeproj/project.pbxproj
+++ b/CourseGrab.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		85B7209D1C37F77FD0A7F126 /* Pods_CourseGrab.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8FE3425F1D82C2F91324A7D8 /* Pods_CourseGrab.framework */; };
 		B654C59123DE38DB00F05141 /* UIColor+Shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = B654C59023DE38DB00F05141 /* UIColor+Shared.swift */; };
 		B654C59323DE38ED00F05141 /* UIFont+Shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = B654C59223DE38ED00F05141 /* UIFont+Shared.swift */; };
+		B6FAEF1B23E9FC5B0076B239 /* HomeTableViewHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6FAEF1A23E9FC5B0076B239 /* HomeTableViewHeader.swift */; };
 		C8626A0D23E34FC20039CC14 /* SearchDetailCardTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8626A0C23E34FC20039CC14 /* SearchDetailCardTableViewCell.swift */; };
 		C877FC1023DE6E07004D06EA /* MainNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C877FC0F23DE6E07004D06EA /* MainNavigationController.swift */; };
 		C8A3D52E23E0D70B0007E488 /* Keys.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8A3D52C23E0D70A0007E488 /* Keys.swift */; };
@@ -49,6 +50,7 @@
 		96351132E2528A1085B69A7A /* Pods-CourseGrab.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CourseGrab.debug.xcconfig"; path = "Target Support Files/Pods-CourseGrab/Pods-CourseGrab.debug.xcconfig"; sourceTree = "<group>"; };
 		B654C59023DE38DB00F05141 /* UIColor+Shared.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Shared.swift"; sourceTree = "<group>"; };
 		B654C59223DE38ED00F05141 /* UIFont+Shared.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+Shared.swift"; sourceTree = "<group>"; };
+		B6FAEF1A23E9FC5B0076B239 /* HomeTableViewHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeTableViewHeader.swift; sourceTree = "<group>"; };
 		C8626A0C23E34FC20039CC14 /* SearchDetailCardTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchDetailCardTableViewCell.swift; sourceTree = "<group>"; };
 		C877FC0F23DE6E07004D06EA /* MainNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainNavigationController.swift; sourceTree = "<group>"; };
 		C8A3D52C23E0D70A0007E488 /* Keys.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Keys.swift; sourceTree = "<group>"; };
@@ -182,6 +184,7 @@
 			isa = PBXGroup;
 			children = (
 				06675D0D23E2859F00AF1884 /* HomeViewController.swift */,
+				B6FAEF1A23E9FC5B0076B239 /* HomeTableViewHeader.swift */,
 				06734A0023E246C800214A3D /* HomeTableViewCell.swift */,
 			);
 			name = Home;
@@ -340,6 +343,7 @@
 				06734A0123E246C900214A3D /* HomeTableViewCell.swift in Sources */,
 				063C67D323E9089F00A40895 /* UIImage+Shared.swift in Sources */,
 				0643489823DE1519007F5F9F /* AppDelegate.swift in Sources */,
+				B6FAEF1B23E9FC5B0076B239 /* HomeTableViewHeader.swift in Sources */,
 				062891B723E8F51F00B6D698 /* SearchViewController.swift in Sources */,
 				C8A3D53823E23C2B0007E488 /* SearchDetailTableViewController.swift in Sources */,
 				C8A3D53A23E23D530007E488 /* SearchDetailTableViewCell.swift in Sources */,

--- a/CourseGrab/Home/HomeTableViewCell.swift
+++ b/CourseGrab/Home/HomeTableViewCell.swift
@@ -125,7 +125,7 @@ class HomeTableViewCell: UITableViewCell {
         titleLabel.text = section.title
 
         if section.status == .open {
-            removeButton.snp.makeConstraints { make in
+            removeButton.snp.remakeConstraints { make in
                 make.top.equalTo(sectionLabel.snp.bottom).offset(12)
                 make.leading.equalTo(16)
                 make.height.equalTo(24)

--- a/CourseGrab/Home/HomeTableViewHeader.swift
+++ b/CourseGrab/Home/HomeTableViewHeader.swift
@@ -1,0 +1,45 @@
+//
+//  HomeTableViewHeader.swift
+//  CourseGrab
+//
+//  Created by Mathew Scullin on 2/4/20.
+//  Copyright © 2020 Cornell AppDev. All rights reserved.
+//
+
+import UIKit
+import SnapKit
+
+class HomeTableViewHeader: UITableViewHeaderFooterView {
+
+    private let titleLabel = UILabel()
+
+    override init(reuseIdentifier: String?) {
+        super.init(reuseIdentifier: reuseIdentifier)
+
+        contentView.backgroundColor = .white
+        titleLabel.font = ._20Semibold
+        contentView.addSubview(titleLabel)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func configure(tableSection: HomeViewController.TableSection, section: Int) {
+        switch tableSection {
+        case .available(let sections):
+            titleLabel.text = "\(sections.count) Available"
+            titleLabel.textColor = .courseGrabGreen
+        case .awaiting(let sections):
+            titleLabel.text = "\(sections.count) Awaiting"
+            titleLabel.textColor = .black
+        }
+        let topPadding = section == 0 ? 24 : 6
+        titleLabel.snp.remakeConstraints { make in
+            make.leading.trailing.equalToSuperview().inset(20)
+            make.bottom.equalToSuperview().inset(6)
+            make.top.equalToSuperview().inset(topPadding)
+        }
+    }
+
+}

--- a/CourseGrab/Home/HomeViewController.swift
+++ b/CourseGrab/Home/HomeViewController.swift
@@ -11,41 +11,66 @@ import Tactile
 
 class HomeViewController: UITableViewController {
 
+    enum TableSection {
+        case available([Section]), awaiting([Section])
+    }
+
     private let homeCellReuseId = "homeCellReuseId"
-    private var sections: [Section] = []
+    private let homeHeaderReuseId = "homeHeaderReuseId"
+    private var tableSections: [TableSection] = []
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        sections = [
+        let availableSections = [
             Section(
-                catalogNum: 103,
-                courseNum: 15821,
-                isTracking: true,
-                section: "LEC 001 / TR 1:25PM",
-                status: .open,
-                subjectCode: "NBA",
-                title: "NBA 3000: Designing New Ventures"
-            ),
-            Section(
-                catalogNum: 51,
-                courseNum: 29424,
-                isTracking: true,
-                section: "DIS 005 / TR 1:25PM",
-                status: .closed,
-                subjectCode: "CS",
-                title: "CS 2112: Data Structures and Algorithms, a Very Long Title"
-            ),
-            Section(
-                catalogNum: 12,
-                courseNum: 5010,
-                isTracking: true,
-                section: "LEC 002 / W 2:10PM",
-                status: .waitlist,
-                subjectCode: "PE",
-                title: "Introductory Rock Climbing"
-            )
-        ]
+            catalogNum: 103,
+            courseNum: 15821,
+            isTracking: true,
+            section: "LEC 001 / TR 1:25PM",
+            status: .open,
+            subjectCode: "NBA",
+            title: "NBA 3000: Designing New Ventures"
+        ),
+        Section(
+            catalogNum: 51,
+            courseNum: 29424,
+            isTracking: true,
+            section: "DIS 005 / TR 1:25PM",
+            status: .open,
+            subjectCode: "CS",
+            title: "CS 2112: Data Structures and Algorithms, a Very Long Title"
+            )]
+        let awaitingSections = [
+        Section(
+            catalogNum: 12,
+            courseNum: 5010,
+            isTracking: true,
+            section: "LEC 002 / W 2:10PM",
+            status: .waitlist,
+            subjectCode: "PE",
+            title: "Introductory Rock Climbing"
+        ),
+        Section(
+            catalogNum: 12345,
+            courseNum: 5010,
+            isTracking: true,
+            section: "LEC 001 / M 2:10PM",
+            status: .closed,
+            subjectCode: "ENGL",
+            title: "Introductory Creative Writing"
+        ),
+        Section(
+            catalogNum: 12345,
+            courseNum: 5010,
+            isTracking: true,
+            section: "LEC 001 / M 2:10PM",
+            status: .closed,
+            subjectCode: "ENGL",
+            title: "Advanced Creative Writing"
+        )]
+
+        tableSections = [.available(availableSections), .awaiting(awaitingSections)]
 
         // Setup navigation bar
         let titleLabel = UILabel()
@@ -64,9 +89,13 @@ class HomeViewController: UITableViewController {
         navigationItem.rightBarButtonItem = UIBarButtonItem(customView: searchButton)
 
         // Setup tableView
+        tableView = UITableView(frame: .zero, style: .grouped)
         tableView.backgroundColor = .white
         tableView.separatorStyle = .none
         tableView.rowHeight = UITableView.automaticDimension
+        tableView.showsVerticalScrollIndicator = false
+        tableView.register(HomeTableViewHeader.self,
+        forHeaderFooterViewReuseIdentifier: homeHeaderReuseId)
         tableView.register(HomeTableViewCell.self, forCellReuseIdentifier: homeCellReuseId)
     }
 
@@ -76,14 +105,31 @@ class HomeViewController: UITableViewController {
 
 extension HomeViewController {
 
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        return tableSections.count
+    }
+
+    override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        let headerView = tableView.dequeueReusableHeaderFooterView(withIdentifier:
+                    homeHeaderReuseId) as! HomeTableViewHeader
+        headerView.configure(tableSection: tableSections[section], section: section)
+        return headerView
+    }
+
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return sections.count
+        switch tableSections[section] {
+        case .available(let sections), .awaiting(let sections):
+            return sections.count
+        }
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: homeCellReuseId, for: indexPath) as! HomeTableViewCell
-        cell.configure(for: sections[indexPath.row])
-        return cell
+        switch tableSections[indexPath.section] {
+        case .available(let sections), .awaiting(let sections):
+            let cell = tableView.dequeueReusableCell(withIdentifier: homeCellReuseId, for: indexPath) as! HomeTableViewCell
+            cell.configure(for: sections[indexPath.row])
+            return cell
+        }
     }
 
 }


### PR DESCRIPTION
## Overview

Added dynamic section headers to `tableView` in `HomeViewController` to reflect the current designs on Zeplin.


## Changes Made

I added a custom `UITableViewHeaderFooterView` that changes depending on the amount and state of the courses the user is tracking. This involved some heavy logic in the `tableView` functions.



## Test Coverage

Using the simulator, I tested all 4 possible scenarios: no courses being tracked, all courses being tracked are open, all are closed, and a mix of the two. Screenshots are attached below.






## Related PRs or Issues 
#19



## Screenshots

<!-- This could include of screenshots of the new feature / proof that the changes work. -->

<details>

  <summary>No Courses Tracked</summary>
  <!-- Insert file link here. Newlines above and below your link are necessary for this to work. -->

![Simulator Screen Shot - iPhone 11 Pro Max - 2020-02-04 at 19 49 30](https://user-images.githubusercontent.com/45302979/73801654-28462a00-4789-11ea-89b8-746ee2d11fc7.png)

</details>

<details>

  <summary>All Open Courses</summary>
  <!-- Insert file link here. Newlines above and below your link are necessary for this to work. -->

![Simulator Screen Shot - iPhone 11 Pro Max - 2020-02-04 at 19 48 00](https://user-images.githubusercontent.com/45302979/73801696-4449cb80-4789-11ea-9ac9-80fad5d9b5fd.png)

</details>
<details>

  <summary>All Closed Courses</summary>
  <!-- Insert file link here. Newlines above and below your link are necessary for this to work. -->

![Simulator Screen Shot - iPhone 11 Pro Max - 2020-02-04 at 19 49 08](https://user-images.githubusercontent.com/45302979/73801722-575c9b80-4789-11ea-8087-7bf3d14036dc.png)

</details>
<details>

  <summary>Mix</summary>
  <!-- Insert file link here. Newlines above and below your link are necessary for this to work. -->

![Simulator Screen Shot - iPhone 11 Pro Max - 2020-02-04 at 19 48 44](https://user-images.githubusercontent.com/45302979/73801734-60e60380-4789-11ea-8ea6-a8bcbc5cef67.png)

</details>



