### PR TITLE
shortened delay to notifications upon tracking course

### DIFF
--- a/CourseGrab/ViewControllers/SearchDetail/SearchDetailTableViewController.swift
+++ b/CourseGrab/ViewControllers/SearchDetail/SearchDetailTableViewController.swift
@@ -89,7 +89,11 @@ extension SearchDetailTableViewController {
                         self.tableView.reloadRows(at: [indexPath], with: .automatic)
                         let banner = NotificationBanner(customView: TrackingBannerView(section: section, isTracking: true))
                         banner.show(queuePosition: .front, queue: bannerQueue)
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 1.15) {
+                            banner.dismiss()
+                        }
                     }
+               
                 case .error(let error):
                     print(error)
                 }
@@ -105,7 +109,11 @@ extension SearchDetailTableViewController {
                         self.tableView.reloadRows(at: [indexPath], with: .automatic)
                         let banner = NotificationBanner(customView: TrackingBannerView(section: section, isTracking: false))
                         banner.show(queuePosition: .front, queue: bannerQueue)
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 1.15) {
+                            banner.dismiss()
+                        }
                     }
+                    
                 case .error(let error):
                     print(error)
                 }


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview

Delayed the time duration of a notification.



## Changes Made

Added a DispatchQueue.main.asyncAfter(){} that lasts 1.15 seconds in SearchDetailTableViewController.



## Test Coverage

Tracked various courses and untracked them to make sure the duration was accurate.






## Screenshots (delete if not applicable)

<!-- This could include of screenshots of the new feature / proof that the changes work. -->

<details>

  <summary>Notifications</summary>


![IMG_2BD28A0FD6C5-1](https://user-images.githubusercontent.com/75585259/141209266-3d0a677c-a3d7-41c6-a4bd-47549566dcf1.jpeg)  

</details>
