### PR TITLE
Update token refresh safety

### DIFF
--- a/CourseGrab/AppDelegate.swift
+++ b/CourseGrab/AppDelegate.swift
@@ -38,6 +38,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Setup push notifications
         UNUserNotificationCenter.current().delegate = self
 
+        NetworkManager.shared.blockValidateToken()
+
         return true
     }
 

--- a/CourseGrab/Network/NetworkManager.swift
+++ b/CourseGrab/Network/NetworkManager.swift
@@ -65,6 +65,14 @@ class NetworkManager {
             .chained { self.networking(Endpoint.getCourse(courseNum: courseNum)).decode() }
     }
 
+    func blockValidateToken() {
+        let semaphore = DispatchSemaphore(value: 0)
+        validateToken().observe { result in
+            semaphore.signal()
+        }
+        semaphore.wait()
+    }
+
     private func validateToken() -> Future<Void> {
         let promise = Promise<Void>()
 

--- a/CourseGrab/ViewControllers/Home/HomeTableViewController.swift
+++ b/CourseGrab/ViewControllers/Home/HomeTableViewController.swift
@@ -184,6 +184,7 @@ extension HomeTableViewController {
                 DispatchQueue.main.async {
                     self.state = .error
                     self.tableView.reloadEmptyDataSet()
+                    User.current?.signOut()
                 }
             }
         }


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview

This PR aims to fix the bug causing users to see 'could not connect to server' after their authentication token has expired. Currently, when an auth token expires, a refresh token call is made; but based on the previous implementation, multiple calls were being made at the same time causing multithreading issues. 

## Changes Made

There are two changes here. 

The first, and more important one, is to have a blocking call to ValidateToken on startup. This means that the app will ensure it has an auth token (if possible) as soon as the app boots. This prevents the on-startup multiple calls to update the token that was previously causing multithreading issues. 

The second change is to log the user out if the token fails to refresh. This is more of a safety feature protecting against the very small chance that the user is using the app while the token needs refreshing and that token refresh failed with a low probability multithreading race condition. In that case, logging the user out forces them to reinitialize an auth session instead of trying to refresh one.

## Test Coverage

In testing out the first feature, I logged the calls to the server functions and checked when they were being called. In every case, they were only being called that one time on startup until a refresh was needed. 

Next, I tested when the refreshes were needed. I ran the server locally and changed the token timeout limit from 3 days to 10 seconds. Thus, after startup, when in the app, I would wait ten seconds, do an action that would cause a refresh, and check the logs to make sure the requests were sent and received as expected. 

In none of the tests, did I come across a situation where the token refresh naturally failed. So to test that I tested running It and then causing the server to throw an update failed mid auth session. This returned a failed token refresh and logged the user out as expected. 

## Next Steps

I think this entire process should be revised to be slightly better. The original app was written with Futures and Promises. This bug fix basically takes away from all the use cases of Futures and Promises. Since that's the case, it seems pointless to keep the entire Futures/Promises when they are needed, or we could update this fix to be more compatible with the way this was originally designed to work.
